### PR TITLE
ZennのRSSを取得する実装を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/khaki/smartrss/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/khaki/smartrss/di/AppModule.kt
@@ -3,9 +3,11 @@ package com.khaki.smartrss.di
 import com.khaki.repository.QiitaFeedRSSRepository
 import com.khaki.repository.RssCategoryRepository
 import com.khaki.repository.RssFeedRepository
+import com.khaki.repository.ZennFeedRSSRepository
 import com.khaki.repositoryimpl.QiitaFeedRSSRepositoryImpl
 import com.khaki.repositoryimpl.RssCategoryRepositoryImpl
 import com.khaki.repositoryimpl.RssFeedRepositoryImpl
+import com.khaki.repositoryimpl.ZennFeedRSSRepositoryImpl
 import com.khaki.smartrss.ui.screen.recomend.RecommendViewModel
 import com.khaki.smartrss.ui.screen.recomend.usecase.RecommendUseCase
 import com.khaki.smartrss.ui.screen.rss.RssViewModel
@@ -19,6 +21,8 @@ val appModule = module {
     // Repository bindings
     singleOf(::QiitaFeedRSSRepositoryImpl) bind QiitaFeedRSSRepository::class
 
+    singleOf(::ZennFeedRSSRepositoryImpl) bind ZennFeedRSSRepository::class
+
     singleOf(::RssCategoryRepositoryImpl) bind RssCategoryRepository::class
 
     singleOf(::RssFeedRepositoryImpl) bind RssFeedRepository::class
@@ -27,6 +31,7 @@ val appModule = module {
     single {
         RssUseCase(
             qiitaFeedsRssRepository = get<QiitaFeedRSSRepository>(),
+            zennFeedsRssRepository = get<ZennFeedRSSRepository>(),
             rssCategoryRepository = get<RssCategoryRepository>(),
             rssFeedRepository = get<RssFeedRepository>(),
         )

--- a/composeApp/src/commonMain/kotlin/com/khaki/smartrss/ui/screen/rss/RssViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/khaki/smartrss/ui/screen/rss/RssViewModel.kt
@@ -41,7 +41,7 @@ class RssViewModel(
                 }
 
                 RegisterableRssGroup.Zenn -> {
-                    // Zenn用のRSSフィード追加ロジックをここに実装
+                    rssUseCase.checkAndAddZennRssFeed(form)
                 }
 
                 RegisterableRssGroup.HatenaBlog -> {

--- a/modules/Api/src/commonMain/kotlin/com/khaki/api/dto/ZennRssFeedDto.kt
+++ b/modules/Api/src/commonMain/kotlin/com/khaki/api/dto/ZennRssFeedDto.kt
@@ -1,0 +1,147 @@
+package com.khaki.api.dto
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+private const val ATOM_NS = "http://www.w3.org/2005/Atom"
+private const val DC_NS = "http://purl.org/dc/elements/1.1/"
+
+@Serializable
+@XmlSerialName("rss")
+data class ZennRssFeedDto(
+    @XmlElement(false)
+    @XmlSerialName("version")
+    val version: String? = null,
+
+    @XmlElement(true)
+    @XmlSerialName("channel")
+    val channel: Channel
+) {
+
+    @Serializable
+    data class Channel(
+        @XmlElement(true)
+        @XmlSerialName("title")
+        val title: String,
+
+        @XmlElement(true)
+        @XmlSerialName("description")
+        val description: String,
+
+        @XmlElement(true)
+        @XmlSerialName("link")
+        val link: String,
+
+        @XmlElement(true)
+        @XmlSerialName("image")
+        val image: Image? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("generator")
+        val generator: String? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("lastBuildDate")
+        val lastBuildDate: String? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("link", namespace = ATOM_NS)
+        val atomLinks: List<AtomLink> = emptyList(),
+
+        @XmlElement(true)
+        @XmlSerialName("language")
+        val language: String? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("item")
+        val items: List<Item> = emptyList()
+    )
+
+    @Serializable
+    data class Image(
+        @XmlElement(true)
+        @XmlSerialName("url")
+        val url: String,
+
+        @XmlElement(true)
+        @XmlSerialName("title")
+        val title: String,
+
+        @XmlElement(true)
+        @XmlSerialName("link")
+        val link: String
+    )
+
+    @Serializable
+    data class AtomLink(
+        @XmlElement(false)
+        @XmlSerialName("href")
+        val href: String? = null,
+
+        @XmlElement(false)
+        @XmlSerialName("rel")
+        val rel: String? = null,
+
+        @XmlElement(false)
+        @XmlSerialName("type")
+        val type: String? = null
+    )
+
+    @Serializable
+    data class Item(
+        @XmlElement(true)
+        @XmlSerialName("title")
+        val title: String,
+
+        @XmlElement(true)
+        @XmlSerialName("description")
+        val description: String,
+
+        @XmlElement(true)
+        @XmlSerialName("link")
+        val link: String,
+
+        @XmlElement(true)
+        @XmlSerialName("guid")
+        val guid: Guid? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("pubDate")
+        val pubDate: String,
+
+        @XmlElement(true)
+        @XmlSerialName("enclosure")
+        val enclosure: Enclosure? = null,
+
+        @XmlElement(true)
+        @XmlSerialName("creator", namespace = DC_NS)
+        val creator: String? = null
+    )
+
+    @Serializable
+    data class Guid(
+        @XmlElement(false)
+        @XmlSerialName("isPermaLink")
+        val isPermaLink: String? = null,
+
+        @XmlValue
+        val value: String? = null
+    )
+
+    @Serializable
+    data class Enclosure(
+        @XmlElement(false)
+        @XmlSerialName("url")
+        val url: String? = null,
+
+        @XmlElement(false)
+        @XmlSerialName("length")
+        val length: String? = null,
+
+        @XmlElement(false)
+        @XmlSerialName("type")
+        val type: String? = null
+    )
+}

--- a/modules/Api/src/commonMain/kotlin/com/khaki/api/service/RSSApiService.kt
+++ b/modules/Api/src/commonMain/kotlin/com/khaki/api/service/RSSApiService.kt
@@ -1,10 +1,13 @@
 package com.khaki.api.service
 
 import com.khaki.api.dto.QiitaRssFeedDto
+import com.khaki.api.dto.ZennRssFeedDto
 
 interface RSSApiService {
 
     suspend fun fetchQiitaRssFeed(requestUrl: String): QiitaRssFeedDto
+
+    suspend fun fetchZennRssFeed(requestUrl: String): ZennRssFeedDto
 
     suspend fun fetchRssFeed(requestUrl: String): String?
 }

--- a/modules/Api/src/commonMain/kotlin/com/khaki/api/service/impl/RssApiServiceImpl.kt
+++ b/modules/Api/src/commonMain/kotlin/com/khaki/api/service/impl/RssApiServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.khaki.api.service.impl
 
 import com.khaki.api.dto.QiitaRssFeedDto
+import com.khaki.api.dto.ZennRssFeedDto
 import com.khaki.api.service.RSSApiService
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -13,6 +14,11 @@ class RssApiServiceImpl(
     override suspend fun fetchQiitaRssFeed(requestUrl: String): QiitaRssFeedDto {
         val response = httpClient.get(requestUrl).bodyAsText()
         return XML.decodeFromString(QiitaRssFeedDto.serializer(), response)
+    }
+
+    override suspend fun fetchZennRssFeed(requestUrl: String): ZennRssFeedDto {
+        val response = httpClient.get(requestUrl).bodyAsText()
+        return XML.decodeFromString(ZennRssFeedDto.serializer(), response)
     }
 
     override suspend fun fetchRssFeed(requestUrl: String): String? {

--- a/modules/RepositoryImpl/src/commonMain/kotlin/com/khaki/repositoryimpl/ZennFeedRSSRepositoryImpl.kt
+++ b/modules/RepositoryImpl/src/commonMain/kotlin/com/khaki/repositoryimpl/ZennFeedRSSRepositoryImpl.kt
@@ -5,7 +5,12 @@ import com.khaki.api.service.RSSApiService
 import com.khaki.modules.core.model.feed.FeedItem
 import com.khaki.modules.core.model.feed.RSSFeed
 import com.khaki.repository.ZennFeedRSSRepository
-import kotlinx.datetime.*
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class ZennFeedRSSRepositoryImpl(
@@ -82,5 +87,7 @@ class ZennFeedRSSRepositoryImpl(
         return nowLocal()
     }
 
-    private fun nowLocal(): LocalDateTime = LocalDateTime(1970, 1, 1, 0, 0, 0)
+    @OptIn(ExperimentalTime::class)
+    private fun nowLocal(): LocalDateTime =
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 }

--- a/modules/RepositoryImpl/src/commonMain/kotlin/com/khaki/repositoryimpl/ZennFeedRSSRepositoryImpl.kt
+++ b/modules/RepositoryImpl/src/commonMain/kotlin/com/khaki/repositoryimpl/ZennFeedRSSRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package com.khaki.repositoryimpl
+
+import com.khaki.api.dto.ZennRssFeedDto
+import com.khaki.api.service.RSSApiService
+import com.khaki.modules.core.model.feed.FeedItem
+import com.khaki.modules.core.model.feed.RSSFeed
+import com.khaki.repository.ZennFeedRSSRepository
+import kotlinx.datetime.*
+import kotlin.time.ExperimentalTime
+
+class ZennFeedRSSRepositoryImpl(
+    private val apiService: RSSApiService
+) : ZennFeedRSSRepository {
+
+    companion object {
+        const val BASE_URL = "https://zenn.dev"
+        private val MONTHS = mapOf(
+            "Jan" to 1, "Feb" to 2, "Mar" to 3, "Apr" to 4, "May" to 5, "Jun" to 6,
+            "Jul" to 7, "Aug" to 8, "Sep" to 9, "Oct" to 10, "Nov" to 11, "Dec" to 12
+        )
+        private val RFC1123_REGEX = Regex(
+            pattern = "^[A-Za-z]{3},\\s(\\d{1,2})\\s([A-Za-z]{3})\\s(\\d{4})\\s(\\d{2}):(\\d{2}):(\\d{2})\\s(GMT|UTC|[+-]\\d{4})$"
+        )
+    }
+
+    override suspend fun popularFeeds(): RSSFeed {
+        val dto = apiService.fetchZennRssFeed("$BASE_URL/feed")
+        return mapToDomain(dto)
+    }
+
+    override suspend fun feedsByTag(tag: String): RSSFeed {
+        val dto = apiService.fetchZennRssFeed("$BASE_URL/topics/$tag/feed")
+        return mapToDomain(dto)
+    }
+
+    override suspend fun feedsByUserId(userId: String): RSSFeed {
+        val dto = apiService.fetchZennRssFeed("$BASE_URL/$userId/feed")
+        return mapToDomain(dto)
+    }
+
+    private fun mapToDomain(dto: ZennRssFeedDto): RSSFeed {
+        val channel = dto.channel
+        return RSSFeed(
+            title = channel.title,
+            link = channel.link,
+            description = channel.description,
+            items = channel.items.map { item ->
+                val id = item.guid?.value ?: item.link
+                FeedItem(
+                    id = id,
+                    title = item.title,
+                    link = item.link,
+                    description = item.description,
+                    pubDate = parsePubDate(item.pubDate),
+                    rssType = FeedItem.RSSType.Zenn(
+                        authorName = item.creator ?: "",
+                        thumbnailUrl = item.enclosure?.url
+                    )
+                )
+            }
+        )
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun parsePubDate(value: String?): LocalDateTime {
+        if (value.isNullOrBlank()) return nowLocal()
+        // Try ISO-8601 first (just in case)
+        runCatching { return Instant.parse(value).toLocalDateTime(TimeZone.currentSystemDefault()) }
+        // Try RFC1123 (e.g. "Sun, 05 Oct 2025 13:54:24 GMT")
+        RFC1123_REGEX.matchEntire(value)?.let { m ->
+            val day = m.groupValues[1].toInt()
+            val monStr = m.groupValues[2]
+            val year = m.groupValues[3].toInt()
+            val hour = m.groupValues[4].toInt()
+            val min = m.groupValues[5].toInt()
+            val sec = m.groupValues[6].toInt()
+            val month = MONTHS[monStr] ?: 1
+            val ldt = LocalDateTime(year, month, day, hour, min, sec)
+            // Treat as UTC regardless of the trailing zone token (Zenn uses GMT)
+            return ldt.toInstant(TimeZone.UTC).toLocalDateTime(TimeZone.currentSystemDefault())
+        }
+        return nowLocal()
+    }
+
+    private fun nowLocal(): LocalDateTime = LocalDateTime(1970, 1, 1, 0, 0, 0)
+}

--- a/modules/core/Repository/src/commonMain/kotlin/com/khaki/repository/ZennFeedRSSRepository.kt
+++ b/modules/core/Repository/src/commonMain/kotlin/com/khaki/repository/ZennFeedRSSRepository.kt
@@ -1,0 +1,12 @@
+package com.khaki.repository
+
+import com.khaki.modules.core.model.feed.RSSFeed
+
+interface ZennFeedRSSRepository {
+
+    suspend fun popularFeeds(): RSSFeed
+
+    suspend fun feedsByTag(tag: String): RSSFeed
+
+    suspend fun feedsByUserId(userId: String): RSSFeed
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ZennのRSSフィードに対応：人気記事・タグ・ユーザーIDから取得可能。
  - RSS追加画面でZennを選択して登録可能に。
- 改善
  - Zenn/Qiitaの取得処理を統一し、取得や日付解析の安定性を向上。
- バグ修正
  - RSS追加時の重複チェックやエラー表示を改善し、見つからない／重複／取得失敗時により適切なメッセージを表示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->